### PR TITLE
Fix ui_matrix CI failure and add Codecov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,12 @@ jobs:
       - run: cargo build --workspace
       - run: cargo test --workspace
       - run: cargo install cargo-llvm-cov --version 0.8.7 --locked
-      - run: cargo llvm-cov --workspace --summary-only -- --skip ui_matrix
-      - run: cargo llvm-cov -p cargo-no-alloc --lib --summary-only
+      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info -- --skip ui_matrix
+      - run: cargo llvm-cov -p cargo-no-alloc --lib --lcov --output-path lcov-driver.info
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: lcov.info,lcov-driver.info
+          fail_ci_if_error: false
       - run: cargo bench --no-run
       - run: cargo install cargo-audit --locked
       - run: cargo audit

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -7,10 +7,12 @@
 //!   `def_path`s plus the verdict kind/reason is the stable, meaningful
 //!   part). This is what should catch a real regression.
 //! - `expected.stderr`: a snapshot of the full rendered diagnostic output,
-//!   including real spans. Machine-specific by nature (rustup install
-//!   paths), so it's explicitly a snapshot, not a portability guarantee —
-//!   re-bless with `NO_ALLOC_BLESS=1` when the toolchain or its install
-//!   path changes.
+//!   including real spans. rustc renders stdlib notes with an absolute
+//!   sysroot path, which varies by machine (`/home/you/.rustup/...` locally
+//!   vs. `/home/runner/.rustup/...` on CI); [`diagnostic_only`] replaces the
+//!   active `rustc --print sysroot` with a `<sysroot>` placeholder so the
+//!   snapshot is portable. Re-bless with `NO_ALLOC_BLESS=1` when the
+//!   toolchain changes and the rendered diagnostics genuinely differ.
 //!
 //! Requires `cargo build --workspace` to have already produced
 //! `cargo-no-alloc`/`no-alloc-driver` in `target/<profile>/` —
@@ -25,9 +27,31 @@ use no_alloc_report::{Report, Verdict};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 static CHECKER_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// The active toolchain's sysroot (e.g.
+/// `/home/you/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu`),
+/// used to scrub machine-specific rustlib source paths out of diagnostic
+/// snapshots. `rust-toolchain.toml` at the workspace root pins the channel,
+/// so this resolves to the same toolchain `cargo-no-alloc` itself invokes.
+fn sysroot() -> &'static str {
+    static SYSROOT: OnceLock<String> = OnceLock::new();
+    SYSROOT.get_or_init(|| {
+        let output = Command::new("rustc")
+            .arg("--print")
+            .arg("sysroot")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .output()
+            .expect("run rustc --print sysroot");
+        assert!(output.status.success(), "rustc --print sysroot failed");
+        String::from_utf8(output.stdout)
+            .expect("rustc sysroot output is UTF-8")
+            .trim()
+            .to_owned()
+    })
+}
 
 fn cargo_no_alloc_bin() -> PathBuf {
     // `PROFILE` is only available to build scripts, not regular crates, so
@@ -73,7 +97,7 @@ fn diagnostic_only(stderr: &str) -> String {
         "Error: Cargo exited with exit status",
         "Error: no_alloc check failed",
     ];
-    stderr
+    let filtered = stderr
         .lines()
         .filter(|line| {
             let trimmed = line.trim_start();
@@ -82,7 +106,8 @@ fn diagnostic_only(stderr: &str) -> String {
                 .any(|prefix| trimmed.starts_with(prefix))
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join("\n");
+    filtered.replace(sysroot(), "<sysroot>")
 }
 
 /// Strips spans (see module doc) and keeps `expected.json` deterministic
@@ -113,6 +138,11 @@ fn run_case(bin: &Path, case_dir: &Path, bless: bool) -> Result<(), String> {
         .current_dir(case_dir)
         .env_remove("NO_ALLOC_WARN_ONLY")
         .env("NO_ALLOC_LOG", "off")
+        // The expected.stderr snapshot is plain text; forcing color off
+        // here keeps the comparison stable regardless of the caller's own
+        // `CARGO_TERM_COLOR` (CI sets `always`, which would otherwise leak
+        // ANSI escapes into the diagnostic and break every snapshot).
+        .env("CARGO_TERM_COLOR", "never")
         .output()
         .map_err(|e| format!("failed to spawn cargo-no-alloc: {e}"))?;
     let stderr = diagnostic_only(&String::from_utf8_lossy(&output.stderr));

--- a/tests/ui/closure_call/expected.stderr
+++ b/tests/ui/closure_call/expected.stderr
@@ -15,12 +15,12 @@ note: via `<std::slice::Iter<'_, u32> as std::iter::Iterator>::next`
    9 |     for &x in buf {
      |               ^^^
 note: via `core::num::<impl usize>::unchecked_sub::precondition_check`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ub_checks.rs:78:17
+    --> <sysroot>/lib/rustlib/src/rust/library/core/src/ub_checks.rs:78:17
      |
   78 |                   precondition_check($($arg,)*);
      |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
-    ::: /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/mod.rs:1449:5
+    ::: <sysroot>/lib/rustlib/src/rust/library/core/src/num/mod.rs:1449:5
      |
 1449 | /     uint_impl! {
 1450 | |         Self = usize,
@@ -31,12 +31,12 @@ note: via `core::num::<impl usize>::unchecked_sub::precondition_check`
 1473 | |     }
      | |_____- in this macro invocation
 note: via `core::panicking::panic_nounwind_fmt`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ub_checks.rs:73:21
+    --> <sysroot>/lib/rustlib/src/rust/library/core/src/ub_checks.rs:73:21
      |
   73 |                       ::core::panicking::panic_nounwind_fmt(::core::fmt::Arguments::from_str(msg), false);
      |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
-    ::: /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/mod.rs:1449:5
+    ::: <sysroot>/lib/rustlib/src/rust/library/core/src/num/mod.rs:1449:5
      |
 1449 | /     uint_impl! {
 1450 | |         Self = usize,

--- a/tests/ui/cross_crate_generic/expected.stderr
+++ b/tests/ui/cross_crate_generic/expected.stderr
@@ -20,12 +20,12 @@ note: via `std::boxed::Box::<usize>::new`
  10 |     fn work() -> usize { *Box::new(1) }
     |                           ^^^^^^^^^^^
 note: via `std::boxed::box_new_uninit`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
     |
 290 |         let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `std::alloc::Global::alloc_impl_runtime`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
     |
 418 | /         core::intrinsics::const_eval_select(
 419 | |             (layout, zeroed),
@@ -34,7 +34,7 @@ note: via `std::alloc::Global::alloc_impl_runtime`
 422 | |         )
     | |_________^
 note: via `alloc::alloc::__rust_alloc_zeroed`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
     |
 284 |         __rust_alloc_zeroed(layout.size(), layout.alignment())
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/direct_alloc/expected.stderr
+++ b/tests/ui/direct_alloc/expected.stderr
@@ -15,12 +15,12 @@ note: via `std::boxed::Box::<i32>::new`
   3 |     let b = Box::new(5i32);
     |             ^^^^^^^^^^^^^^
 note: via `std::boxed::box_new_uninit`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
     |
 290 |         let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `std::alloc::Global::alloc_impl_runtime`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
     |
 418 | /         core::intrinsics::const_eval_select(
 419 | |             (layout, zeroed),
@@ -29,7 +29,7 @@ note: via `std::alloc::Global::alloc_impl_runtime`
 422 | |         )
     | |_________^
 note: via `alloc::alloc::__rust_alloc_zeroed`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
     |
 284 |         __rust_alloc_zeroed(layout.size(), layout.alignment())
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/drop_dyn/expected.stderr
+++ b/tests/ui/drop_dyn/expected.stderr
@@ -15,19 +15,19 @@ note: via `std::ptr::drop_glue::<std::boxed::Box<dyn Greet>> - shim(Some(std::bo
   15 | }
      | ^
 note: via `<std::boxed::Box<dyn Greet> as std::ops::Drop>::drop`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
+    --> <sysroot>/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
      |
  828 | / pub(crate) const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
  829 | | where
  830 | |     T: [const] Destruct,
      | |________________________^
 note: via `<std::alloc::Global as std::alloc::Allocator>::deallocate`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1995:17
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1995:17
      |
 1995 |                 self.1.deallocate(From::from(ptr.cast()), layout);
      |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `alloc::alloc::__rust_dealloc`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:169:14
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:169:14
      |
  169 |     unsafe { __rust_dealloc(ptr, layout.size(), layout.alignment()) }
      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/drop_field/expected.stderr
+++ b/tests/ui/drop_field/expected.stderr
@@ -26,45 +26,45 @@ note: via `std::ptr::drop_glue::<Holder> - shim(Some(Holder))`
   6 | }
     | ^
 note: via `std::ptr::drop_glue::<std::string::String> - shim(Some(std::string::String))`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
+   --> <sysroot>/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
     |
 828 | / pub(crate) const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
 829 | | where
 830 | |     T: [const] Destruct,
     | |________________________^
 note: via `std::ptr::drop_glue::<std::vec::Vec<u8>> - shim(Some(std::vec::Vec<u8>))`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
+   --> <sysroot>/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
     |
 828 | / pub(crate) const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
 829 | | where
 830 | |     T: [const] Destruct,
     | |________________________^
 note: via `std::ptr::drop_glue::<alloc::raw_vec::RawVec<u8>> - shim(Some(alloc::raw_vec::RawVec<u8>))`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
+   --> <sysroot>/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
     |
 828 | / pub(crate) const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
 829 | | where
 830 | |     T: [const] Destruct,
     | |________________________^
 note: via `<alloc::raw_vec::RawVec<u8> as std::ops::Drop>::drop`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
+   --> <sysroot>/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:828:1
     |
 828 | / pub(crate) const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
 829 | | where
 830 | |     T: [const] Destruct,
     | |________________________^
 note: via `alloc::raw_vec::RawVecInner::deallocate`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:425:18
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:425:18
     |
 425 |         unsafe { self.inner.deallocate(T::LAYOUT) }
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `<std::alloc::Global as std::alloc::Allocator>::deallocate`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:876:17
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:876:17
     |
 876 |                 self.alloc.deallocate(ptr, layout);
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `alloc::alloc::__rust_dealloc`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:169:14
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:169:14
     |
 169 |     unsafe { __rust_dealloc(ptr, layout.size(), layout.alignment()) }
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/drop_in_one_arm/expected.stderr
+++ b/tests/ui/drop_in_one_arm/expected.stderr
@@ -15,32 +15,32 @@ note: via `std::vec::Vec::<i32>::push`
    5 |         v.push(1);
      |         ^^^^^^^^^
 note: via `std::vec::Vec::<i32>::push_mut`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:996:17
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:996:17
      |
  996 |         let _ = self.push_mut(value);
      |                 ^^^^^^^^^^^^^^^^^^^^
 note: via `alloc::raw_vec::RawVec::<i32>::grow_one`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:1033:13
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:1033:13
      |
 1033 |             self.buf.grow_one();
      |             ^^^^^^^^^^^^^^^^^^^
 note: via `alloc::raw_vec::RawVecInner::grow_amortized`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:493:36
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:493:36
      |
  493 |         if let Err(err) = unsafe { self.grow_amortized(self.cap.as_inner(), 1, elem_layout) } {
      |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `alloc::raw_vec::RawVecInner::finish_grow`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:529:28
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:529:28
      |
  529 |         let ptr = unsafe { self.finish_grow(cap, elem_layout)? };
      |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `<std::alloc::Global as std::alloc::Allocator>::allocate`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:560:13
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/raw_vec/mod.rs:560:13
      |
  560 |             self.alloc.allocate(new_layout)
      |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `std::alloc::Global::alloc_impl_runtime`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
      |
  418 | /         core::intrinsics::const_eval_select(
  419 | |             (layout, zeroed),
@@ -49,7 +49,7 @@ note: via `std::alloc::Global::alloc_impl_runtime`
  422 | |         )
      | |_________^
 note: via `alloc::alloc::__rust_alloc_zeroed`
-    --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
+    --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
      |
  284 |         __rust_alloc_zeroed(layout.size(), layout.alignment())
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/generic_split/expected.stderr
+++ b/tests/ui/generic_split/expected.stderr
@@ -20,12 +20,12 @@ note: via `std::boxed::Box::<i32>::new`
   8 |         *Box::new(x)
     |          ^^^^^^^^^^^
 note: via `std::boxed::box_new_uninit`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
     |
 290 |         let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `std::alloc::Global::alloc_impl_runtime`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
     |
 418 | /         core::intrinsics::const_eval_select(
 419 | |             (layout, zeroed),
@@ -34,7 +34,7 @@ note: via `std::alloc::Global::alloc_impl_runtime`
 422 | |         )
     | |_________^
 note: via `alloc::alloc::__rust_alloc_zeroed`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
     |
 284 |         __rust_alloc_zeroed(layout.size(), layout.alignment())
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/global_allocator/expected.stderr
+++ b/tests/ui/global_allocator/expected.stderr
@@ -15,12 +15,12 @@ note: via `std::boxed::Box::<i32>::new`
  18 |     *Box::new(9)
     |      ^^^^^^^^^^^
 note: via `std::boxed::box_new_uninit`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/boxed.rs:290:19
     |
 290 |         let ptr = box_new_uninit(<T as SizedTypeProperties>::LAYOUT) as *mut T;
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: via `std::alloc::Global::alloc_impl_runtime`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:418:9
     |
 418 | /         core::intrinsics::const_eval_select(
 419 | |             (layout, zeroed),
@@ -29,7 +29,7 @@ note: via `std::alloc::Global::alloc_impl_runtime`
 422 | |         )
     | |_________^
 note: via `alloc::alloc::__rust_alloc_zeroed`
-   --> /home/dw/.rustup/toolchains/nightly-2026-08-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
+   --> <sysroot>/lib/rustlib/src/rust/library/alloc/src/alloc.rs:284:9
     |
 284 |         __rust_alloc_zeroed(layout.size(), layout.alignment())
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

- `ui_matrix` has failed on every CI run since it was introduced (3/3
  runs). Root cause: the committed `tests/ui/*/expected.stderr`
  snapshots were blessed on a local dev machine and hardcode its
  absolute rustup sysroot path (`/home/dw/.rustup/toolchains/...`) plus
  colorless text. Neither matches the CI runner, which uses a different
  `$HOME` (`/home/runner`) and inherits `CARGO_TERM_COLOR=always` into
  the spawned `cargo-no-alloc` child process, corrupting the diff with
  ANSI escapes.
- Fix: `tests/ui.rs` now resolves the active toolchain's sysroot via
  `rustc --print sysroot` and scrubs it to a stable `<sysroot>`
  placeholder before comparing, and forces `CARGO_TERM_COLOR=never` on
  the spawned checker process so the snapshot is deterministic
  regardless of the caller's environment. Re-blessed the 8 affected
  `expected.stderr` files under the new normalization.
- Added Codecov coverage: the existing `cargo llvm-cov` steps now emit
  lcov reports (instead of `--summary-only`), uploaded via
  `codecov/codecov-action` (pinned to v7.0.0 by commit SHA). No
  `CODECOV_TOKEN` secret configured yet — tokenless upload works for
  public repos but may rate-limit; happy to add the secret if that
  becomes an issue.

## Test plan

- [x] `cargo test --workspace` passes locally, including `ui_matrix`
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo llvm-cov --workspace --lcov --output-path lcov.info -- --skip ui_matrix` and `cargo llvm-cov -p cargo-no-alloc --lib --lcov --output-path lcov-driver.info` both produce valid lcov output locally
- [ ] CI green on this PR (will confirm once it runs)

https://claude.ai/code/session_015mrGUEoCfiHQfXAS9ypoPu