### PR TITLE
Remove rust automerge prevention rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,20 +11,4 @@
     enabled: true,
     schedule: [],
   },
-  packageRules: [
-    {
-      matchManagers: ['cargo'],
-      rangeStrategy: 'replace',
-    },
-    {
-      // nightly-2026-08-01 is pinned deliberately: the rustc-internals
-      // crates (rustc_middle, rustc_interface, ...) have no stability
-      // guarantee across nightlies, and no_alloc_analysis's driver is
-      // verified against this exact version. See AGENTS.md. Still raise
-      // the PR so a bump is visible, but never let it merge unattended.
-      matchManagers: ['rust-toolchain'],
-      matchDepNames: ['rust'],
-      automerge: false,
-    },
-  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,4 +11,10 @@
     enabled: true,
     schedule: [],
   },
+  packageRules: [
+    {
+      matchManagers: ['cargo'],
+      rangeStrategy: 'replace',
+    },
+  ],
 }


### PR DESCRIPTION
## What and why

<!-- What does this change, and why? -->

## Checklist

- [ ] Ran the verification commands in [CONTRIBUTING.md](../CONTRIBUTING.md#build-and-test) (`cargo fmt`, `cargo clippy`, `cargo test --workspace`, `cargo llvm-cov`, `cargo bench`, `cargo audit`)
- [ ] If this changes an edge-table rule or the leaf set: added a new fixture under `tests/ui/<case>/`, not just an assertion bolted onto an existing case (see [CONTRIBUTING.md](../CONTRIBUTING.md#regression-tests))
- [ ] If this touches `crates/no_alloc_analysis`: preserves "reject, don't assume" for unresolved call edges ([ADR 0003](../adr/0003-reject-unresolved-edges.md); see [CONTRIBUTING.md](../CONTRIBUTING.md#soundness))
